### PR TITLE
Update `mkmovie.py`: cleanup, modernization, and improvements

### DIFF
--- a/galaxies/spiral_windup/spiral_windup.py
+++ b/galaxies/spiral_windup/spiral_windup.py
@@ -1,5 +1,4 @@
-import math
-import numpy
+import numpy as np
 import pylab
 
 # illustrate the wind-up problem of spiral arms
@@ -9,20 +8,11 @@ import pylab
 
 # define the rotation curve 
 def vel(r):
-
-    ar = math.fabs(r)
-    if (ar <= 5.0):
-        v = 1.4*ar*math.exp(-ar/20.0)
-    elif (ar > 5.0 and ar < 6.0):
-        max = 1.4*5*math.exp(-5.0/20.0)
-        min = 5.0
-        m = (max - min)/(-1.0)
-        v = m*(ar - 5.0) + max
-    else:
-        v = 5.0
-
-    return v
-
+    ar = np.abs(r)
+    return np.piecewise(ar, [ar<=5.0, ar>5.0 and ar<6.0],
+                        [lambda x: 1.4*x*np.exp(-x/20.0),
+                         lambda x: (5.0 - 7.0*np.exp(-0.25))*(x - 5.0) + 7.0*np.exp(-0.25),
+                         lambda x: 5])
 
 
 def spiral():
@@ -31,16 +21,16 @@ def spiral():
     rmax = 20
     npts = 1000
 
-    r = numpy.arange(npts, dtype=numpy.float64)*(rmax - rmin)/(npts - 1.0) + rmin
+    r = np.arange(npts, dtype=np.float64)*(rmax - rmin)/(npts - 1.0) + rmin
 
-    omega = numpy.zeros( npts )
+    omega = np.zeros( npts )
 
     n = 0
     while (n < npts):
-        omega[n] = math.fabs(vel(r[n])/r[n])
+        omega[n] = np.abs(vel(r[n])/r[n])
         n += 1
 
-        
+    t = np.arange(0.0, 20.0, 0.04)
     t = 0.0
     tmax = 20.0
     dt = 0.04
@@ -52,8 +42,8 @@ def spiral():
         
         pylab.clf()
 
-        x = r*numpy.cos(omega*t)
-        y = r*numpy.sin(omega*t)
+        x = r*np.cos(omega*t)
+        y = r*np.sin(omega*t)
 
         pylab.plot(x,y,color="b")
 
@@ -74,7 +64,3 @@ def spiral():
 
 if __name__== "__main__":
     spiral()
-
-
-    
-        

--- a/scripts/mkmovie.py
+++ b/scripts/mkmovie.py
@@ -59,7 +59,7 @@ if (args.avi):
 
     with open("_mkmovie1.list", "w+") as f:
         # input list file for mencoder
-        f.writelines(avi_frames)
+        f.write("\n".join(avi_frames))
 
     try:
         p = subprocess.run("mencoder mf://@_mkmovie1.list -ovc lavc -lavcopts "
@@ -97,7 +97,7 @@ if (args.mp4):
     
     with open("_mkmovie2.list", "w+") as f:
         # input list file for mencoder
-        f.writelines(mp4_frames)
+        f.write("\n".join(mp4_frames))
 
     try:
         subprocess.run("mencoder mf://@_mkmovie2.list -of lavf -lavfopts format=mp4 "

--- a/scripts/mkmovie.py
+++ b/scripts/mkmovie.py
@@ -1,43 +1,7 @@
 #!/usr/bin/env python
 
-desc = """ 
-python driver to mencoder.  Take a list of files and make avi and mp4 movies.
-
-./mkmovie.py [options] <list of PNG files>
-
-options:
-
-  -h, --help    : print this help page
-
-  -f x, --fps=x : set frames per second to be x
-
-  --double      : double each frame (effectively 2x slower)
-
-  -N num        : create N copies of each frame (to really slow it down)
- 
-  -o prefix     : prefix for the movies (default: movie)
-
-  --avi         : only generate an avi movie
-
-  --mp4         : only generate an mp4 movie
-
-  --endframes=N : add N duplicate frames to the end, to make the last 
-                   frame persist
-
-Note: for the mp4 movies, we duplicate the frames at the start to get
-around a bug (?) in mencoder that skips some frames at the start.
-
-M. Zingale (2013-02-19)
-
-R. Orvedahl (2014-07-18)
-	-add more options
-	-change calling sequences
-
-"""
-
-import sys
 import os
-import getopt
+import argparse
 import re
 
 # routines for natural/human sorting
@@ -50,57 +14,28 @@ def natural_keys(text):
     return [ atoi(c) for c in re.split('(\d+)', text) ]
 
 
-if len(sys.argv) == 1:
-    print desc
-    sys.exit(2)
+parser = argparse.ArgumentParser(description="python driver to mencoder.  Take a list of files and make avi and mp4 movies.",
+                                 usage="./mkmovie.py [options] <list of PNG files>",
+                                 epilog="Note: for the mp4 movies, we duplicate the frames at the start to get\n"
+                                        "around a bug (?) in mencoder that skips some frames at the start.\n\n"
+                                        "M. Zingale (2013-02-19)\n\nR. Orvedahl (2014-07-18)\n\t-add more options\n\t"
+                                        "-change calling sequences\n\n C. Gobat (2023-07-19)\n\t-use argparse instead of getopt",
+                                 formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument("-f", "--fps", metavar="x", default=15, type=int, help="set frames per second to be x (default: 15)")
+duplication = parser.add_mutually_exclusive_group()
+duplication.add_argument("--double", action="store_true", help="double each frame (effectively 2x slower)")
+duplication.add_argument("-N", dest="ncopies", metavar="num", default=1, type=int, help="create N copies of each frame (to really slow it down)")
+parser.add_argument("-o", dest="prefix", metavar="prefix", default="movie", help="prefix for the movies (default: movie)")
+movie_type = parser.add_mutually_exclusive_group()
+movie_type.add_argument("--avi", dest="mp4", action="store_false", help="only generate an avi movie")
+movie_type.add_argument("--mp4", dest="avi", action="store_false", help="only generate an mp4 movie")
+parser.add_argument("--endframes", dest="endFrames", metavar="N", default=1, type=int, help="add N duplicate frames to the end, to make the last frame persist")
+parser.add_argument("input_frames", nargs="+", help="list of image file paths/names to use as frames in the movie")
 
+args = parser.parse_args()
+frames = list(args.input_frames)
 
-prefix = "movie"
-endFrames = 1
-double = False
-ncopies = 1
-avi = True
-mp4 = True
-fps = 15
-
-try: opts, next = getopt.getopt(sys.argv[1:], "ho:N:f:", 
-                                ["double", "endframes=", "avi", "mp4", 
-                                 "fps=", "help"])
-except getopt.GetoptError:
-    sys.exit("invalid calling sequence")
-
-for o, a in opts:
-
-    if o == "-o":
-        prefix = a
-
-    elif (o == "--fps" or o == "-f"):
-        fps = a
-
-    elif (o == "--help" or o == "-h"):
-        print desc
-        sys.exit(2)
-
-    elif o == "--double":
-        double = True
-
-    elif o == "-N":
-        ncopies = int(a)
-
-    elif o == "--endframes":
-        endFrames = int(a)
-
-    elif o == "--avi":
-        mp4 = False
-
-    elif o == "--mp4":
-        avi = False
-
-try: frames = next[0:]
-except IndexError:
-    sys.exit("no frames specified")
-
-print "number of frames: ", len(frames)
+print("number of frames: ", len(frames))
 
 # sort frames
 frames.sort(key=natural_keys)
@@ -108,27 +43,27 @@ frames.sort(key=natural_keys)
 # create temporary files that list the movie frames -- these are inputs
 # to mencoder
 
-if (avi):
+if (args.avi):
     f = open("_mkmovie1.list", "w")
 
     for img in frames:
         f.write("%s\n" % (img))
-        if double:
+        if args.double:
             f.write("%s\n" % (img))
-        elif ncopies > 1:
-            for i in range(ncopies):
+        elif args.ncopies > 1:
+            for i in range(args.ncopies):
                 f.write("%s\n" % (img))
 
-    if endFrames > 1:
+    if args.endFrames > 1:
         n = 0
-        while (n < endFrames-1):
+        while (n < args.endFrames-1):
             f.write("%s\n" % (frames[len(frames)-1]))        
             n += 1
 
     f.close()
 
 
-if (mp4):
+if (args.mp4):
     # for mp4, we want some extra frames at the start
     f = open("_mkmovie2.list", "w")
 
@@ -139,15 +74,15 @@ if (mp4):
 
     for img in frames:
         f.write("%s\n" % (img))
-        if double:
+        if args.double:
             f.write("%s\n" % (img))
-        elif ncopies > 1:
-            for i in range(ncopies):
+        elif args.ncopies > 1:
+            for i in range(args.ncopies):
                 f.write("%s\n" % (img))
 
-    if endFrames > 1:
+    if args.endFrames > 1:
         n = 0
-        while (n < endFrames-1):
+        while (n < args.endFrames-1):
             f.write("%s\n" % (frames[len(frames)-1]))        
             n += 1
 
@@ -156,36 +91,36 @@ if (mp4):
 
 
 # make the movies
-if (avi):
+if (args.avi):
     str1 = "mencoder mf://@_mkmovie1.list -ovc lavc -lavcopts "
     str2 = "vcodec=msmpeg4v2:vbitrate=3000:vhq:mbd=2:trell "
-    str3 = "-mf type=png:fps="+str(fps)
-    str4 = " -o %s.avi" % (prefix)
+    str3 = "-mf type=png:fps="+str(args.fps)
+    str4 = f" -o {args.prefix}.avi"
     os.system(str1+str2+str3+str4)
 
-if (mp4):
+if (args.mp4):
     str1 = "mencoder mf://@_mkmovie2.list -of lavf -lavfopts format=mp4 "
     str2 = "-ss 1 -ovc x264 -x264encopts crf=20.0:nocabac:level_idc=30:"
-    str3 = "global_header:threads=2 -fps "+str(fps)
-    str4 = " -o %s.mp4" % (prefix)
+    str3 = "global_header:threads=2 -fps "+str(args.fps)
+    str4 = f" -o {args.prefix}.mp4"
     os.system(str1+str2+str3+str4)
 
     str1 = "mencoder mf://@_mkmovie2.list -ovc x264 -x264encopts crf=10:"
     str2 = "me=umh:subq=9:nr=100:global_header -of lavf -lavfopts format=mp4 "
-    str3 = "-fps "+str(fps)
-    str4 = " -o %s_hg.mp4" % (prefix)
+    str3 = "-fps "+str(args.fps)
+    str4 = f" -o {args.prefix}_hg.mp4"
     os.system(str1+str2+str3+str4)
 
 
 # remove the files
-if (avi):
+if (args.avi):
     os.remove("_mkmovie1.list")
-if (mp4):
+if (args.mp4):
     os.remove("_mkmovie2.list")
 
-if (avi):
-    print "\n Avi Movie: "+prefix+".avi"
-if (mp4):
-    print "\n Mp4 Movie: "+prefix+".mp4"
-    print "\n Mp4 Movie: "+prefix+"_hg.mp4"
+if (args.avi):
+    print(f"\n Avi Movie: {args.prefix}.avi")
+if (args.mp4):
+    print(f"\n Mp4 Movie: {args.prefix}.mp4")
+    print(f"\n Mp4 Movie: {args.prefix}_hg.mp4")
 


### PR DESCRIPTION
This PR encompasses a number of updates to the `mkmovie.py` script. It should still be entirely backwards-compatible (i.e. existing workflows will not have to be modified). The changes are summarized as follows:

* Command-line argument parsing: use `argparse` instead of `getopt`
  * Like `getopt`, [`argparse`](https://docs.python.org/3/library/argparse.html) is a part of the Python standard library, but facilitates a higher degree of code readability/clarity/maintainability
* Calling external programs: use `subprocess` instead of `os.system`
  * The [`subprocess`](https://docs.python.org/3/library/subprocess.html) module (also part of the standard library) is preferable to `os.system` calls for [a number of reasons](https://stackoverflow.com/q/44730935/4450498). Even the [`os.system` documentation](https://docs.python.org/3/library/os.html#os.system) itself mentions this.
* Add OpenCV-based movie generation routine as a backup in case `mencoder` fails
  * `mencoder` isn't available on all systems (e.g. Windows), or sometimes has issues. In case it causes an error, this PR adds an alternative [`cv2.VideoWriter`](https://docs.opencv.org/4.x/dd/d9e/classcv_1_1VideoWriter.html)-based pathway for generating movies from the same inputs.
  * Whether or not the script uses `mencoder` or `cv2.VideoWriter` to do the encoding/movie generation is transparent to the user.
  * OpenCV (`cv2`) not being installed is not a problem as long as `mencoder` works.
* General code cleanup and modernization
  * Excess verbosity has been trimmed (e.g. removal of unnecessary loops, more compact logic/control flow, etc.)
  * Make better use of Python's full capabilities (e.g. [f-strings](https://docs.python.org/3/tutorial/inputoutput.html#tut-f-strings) instead of `%`-based formatting, negative indexing instead of `x[len(x)-1]`, etc.)